### PR TITLE
Add Google analytics capabilities

### DIFF
--- a/web_external/main.js
+++ b/web_external/main.js
@@ -18,4 +18,8 @@ $(() => {
         parentView: null
     });
     events.trigger('g:appload.after', app);
+
+    if (process.env.GA_KEY) {
+      console.log(process.env.GA_KEY);
+    }
 });

--- a/web_external/main.js
+++ b/web_external/main.js
@@ -24,7 +24,7 @@ $(() => {
         let dataLayer = window.dataLayer;
         dataLayer = dataLayer || [];
         const gtag = function () {
-          dataLayer.push(arguments);
+            dataLayer.push(arguments);
         };
         gtag('js', new Date());
         gtag('config', gaKey);

--- a/web_external/main.js
+++ b/web_external/main.js
@@ -12,14 +12,27 @@ import './stylesheets/item.comments.styl';
 import './routes';
 
 $(() => {
+    const gaKey = process.env.GA_KEY;
+    if (gaKey) {
+      // Inject the Google Analytics framework.
+      let s = document.createElement('script');
+      s.type = 'text/javascript';
+      s.src = `https://www.googletagmanager.com/gtag/js?id=${gaKey}`;
+      document.getElementsByTagName('head')[0].appendChild(s);
+
+      // Launch tracking for this site.
+      window.dataLayer = window.dataLayer || [];
+      const gtag = function () {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', gaKey);
+    }
+
     events.trigger('g:appload.before');
     const app = new App({
         el: 'body',
         parentView: null
     });
     events.trigger('g:appload.after', app);
-
-    if (process.env.GA_KEY) {
-      console.log(process.env.GA_KEY);
-    }
 });

--- a/web_external/main.js
+++ b/web_external/main.js
@@ -14,19 +14,20 @@ import './routes';
 $(() => {
     const gaKey = process.env.GA_KEY;
     if (gaKey) {
-      // Inject the Google Analytics framework.
-      let s = document.createElement('script');
-      s.type = 'text/javascript';
-      s.src = `https://www.googletagmanager.com/gtag/js?id=${gaKey}`;
-      document.getElementsByTagName('head')[0].appendChild(s);
+        // Inject the Google Analytics framework.
+        let s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.src = `https://www.googletagmanager.com/gtag/js?id=${gaKey}`;
+        document.getElementsByTagName('head')[0].appendChild(s);
 
-      // Launch tracking for this site.
-      window.dataLayer = window.dataLayer || [];
-      const gtag = function () {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', gaKey);
+        // Launch tracking for this site.
+        let dataLayer = window.dataLayer;
+        dataLayer = dataLayer || [];
+        const gtag = function () {
+          dataLayer.push(arguments);
+        };
+        gtag('js', new Date());
+        gtag('config', gaKey);
     }
 
     events.trigger('g:appload.before');

--- a/webpack.helper.js
+++ b/webpack.helper.js
@@ -1,0 +1,9 @@
+var webpack = require('webpack');
+
+module.exports = function (config, info) {
+  config.plugins.push(new webpack.EnvironmentPlugin({
+    GA_KEY: ''
+  }));
+
+  return config;
+};


### PR DESCRIPTION
This PR adds Google analytics capabilities to tech_journal.

To activate it requires supplying a Google Analytics tracking ID at build time: `GA_KEY=<google analytics ID> girder-install web`

Closes #19 