### PR TITLE
Fix the "Pending Submission" process

### DIFF
--- a/web_external/pages/home/home.js
+++ b/web_external/pages/home/home.js
@@ -65,22 +65,25 @@ const HomePage = View.extend({
     },
     render: function (subData, searchVal, collection) {
         var pendingSubs = 0;
-        subData.forEach(function (d) {
-            if (d.curation.status === 'REQUESTED') { pendingSubs++; }
-        });
         restRequest({
             type: 'GET',
             path: `journal/${collection}/issues`
         }).done((jrnResp) => {
-            this.$el.html(HomeTemplate({
-                info: { 'issues': jrnResp }
-            }));
-            this.$('.searchResults').html(this.$('.searchResults').html() + IndexEntryViewTemplate({info: {'submissions': subData}}));
-            new MenuBarView({ // eslint-disable-line no-new
-                el: this.$el,
-                parentView: this,
-                searchBoxVal: searchVal,
-                pendingSubNum: pendingSubs
+            restRequest({
+                type: 'GET',
+                path: `journal/${this.defaultJournal}/pending?`
+            }).done((pendRsp) => {
+                pendingSubs = pendRsp.length;
+                this.$el.html(HomeTemplate({
+                    info: { 'issues': jrnResp }
+                }));
+                this.$('.searchResults').html(this.$('.searchResults').html() + IndexEntryViewTemplate({info: {'submissions': subData}}));
+                new MenuBarView({ // eslint-disable-line no-new
+                    el: this.$el,
+                    parentView: this,
+                    searchBoxVal: searchVal,
+                    pendingSubNum: pendingSubs
+                });
             });
         });
 

--- a/web_external/views/manageApproval.js
+++ b/web_external/views/manageApproval.js
@@ -15,24 +15,16 @@ var manageApprovalView = View.extend({
             path: 'journal/setting',
             data: {
                 list: JSON.stringify([
-                    'technical_journal.default_journal'
+                    'tech_journal.default_journal'
                 ])
             }
         }).done((resp) => {
+            console.log(resp);
             restRequest({
                 type: 'GET',
-                path: `journal/${resp['technical_journal.default_journal']}/submissions?filterID=*`,
-                params: {
-                    filterID: '*'
-                }
+                path: `journal/${resp['tech_journal.default_journal']}/pending?`
             }).done((jrnResp) => {
-                var approvalSubs = [];
-                jrnResp.forEach(function (sub) {
-                    if (sub.curation.status === 'REQUESTED') {
-                        approvalSubs.push(sub);
-                    }
-                });
-                this.render(approvalSubs);
+                this.render(jrnResp);
             });
         });
     },


### PR DESCRIPTION
Fix the pending submission to not use the API for getting all submissions
Instead, use a separate one that only returns the pending submissions
and use the same call to gather the amount of submissions on the main
page for administrators.