### PR TITLE
Fix MenuBar links that go to Girder proper

### DIFF
--- a/web_external/templates/journal_menu_bar.pug
+++ b/web_external/templates/journal_menu_bar.pug
@@ -59,14 +59,14 @@
             | New Publication
         if user
           li#profileLink
-            a(href='#user/' + user.id) My Profile
+            a(href='/#user/' + user.id) My Profile
             #userOptionsDiv
               ul#userOptionsList
                 li
                   // TODO: implement this route
                   a.submm(href='#?query="creatorId":"'+user.id+'"') My Publications
                 li
-                  a.submm(href='#useraccount/' + user.id + '/info') Edit Profile
+                  a.submm(href='/#useraccount/' + user.id + '/info') Edit Profile
           if user.attributes.admin
             li#adminLink
               a(href="") Admin
@@ -75,7 +75,7 @@
                   li
                     a.submm(href='#plugins/journal/admin') Journals
                   li
-                    a.submm(href='#users') Users
+                    a.submm(href='/#users') Users
                   li
                     a.submm.
                       Categories


### PR DESCRIPTION
Fix the few menu links that point to the girder pages instead of
a tech_journal page.

Fixes issue #45 