### PR TITLE
Replace Girder ID values with english

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -208,10 +208,20 @@ class TechJournal(Resource):
     def getSubmissionDetails(self, folder, params):
         parentInfo = self.model('folder').load(folder['parentId'],
                                                user=self.getCurrentUser(), force=True)
+        parentInfo['issue'] = self.model('folder').load(parentInfo['parentId'],
+                                                        user=self.getCurrentUser(),
+                                                        force=True)
+        parentInfo['submitter'] = self.model('user').load(folder['creatorId'],
+                                                          user=self.getCurrentUser(),
+                                                          force=True)
         currentInfo = self.model('folder').load(folder['_id'],
                                                 user=self.getCurrentUser(), force=True)
         otherRevs = list(self.model('folder').childFolders(parentType='folder', parent=parentInfo,
                                                            user=self.getCurrentUser()))
+        for rev in otherRevs:
+            rev['submitter'] = self.model('user').load(rev['creatorId'],
+                                                       user=self.getCurrentUser(),
+                                                       force=True)
         return (currentInfo, parentInfo, otherRevs)
 
     @access.public(scope=TokenScope.DATA_READ)

--- a/web_external/pages/view/journal_view.pug
+++ b/web_external/pages/view/journal_view.pug
@@ -3,7 +3,7 @@ mixin revisionOption(value,selectedRev)
     td.
       #{value.name}
     td.
-      #{value.creatorId}
+      #{value.submitter.firstName} #{value.submitter.lastName}
     td.
       #{value.created}
     td.
@@ -110,9 +110,9 @@ if 'downloadStatistics' in info.revision
             span(style="font-weight:bold;color:red;")
               | This article is waiting for approval
           .journal.
-            Submitted to: #{info.parent.baseParentId}
+            Submitted to: #{info.parent.issue.name}
           .submittedby.
-            Submitted by #{info.parent.creatorId} on #{info.parent.created}
+            Submitted by #{info.parent.submitter.firstName} #{info.parent.submitter.lastName} on #{info.parent.created}
           if info.revision.description
             h4 Revision Notes
             .abstract(style="text-align: justify")


### PR DESCRIPTION
Replace the submitter name and submission issue with their real name as
opposed to the Girder IDs that are maintained in the folder info.