### PR TITLE
Switch ordering to use update of latest revision

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -382,7 +382,8 @@ class TechJournal(Resource):
                     # If not found already, add it to the returned information
                     if submission not in totalData:
                         totalData.append(submission)
-        totalData = sorted(totalData, reverse=True, key=lambda submission: submission['updated'])
+        totalData = sorted(totalData, reverse=True,
+                           key=lambda submission: submission['currentRevision']['updated'])
         return totalData
 
     @access.public(scope=TokenScope.DATA_READ)


### PR DESCRIPTION
Switch from using the update of the overall submission, which would change
when a comment is added, to the update date of the latest revision.