### PR TITLE
Switch from email to first.last for login name

### DIFF
--- a/midas_girder_connection.py
+++ b/midas_girder_connection.py
@@ -125,7 +125,7 @@ def ReadAll( prevAssetDir, baseParent=None, assetStore=None,):
                     "lastName":user[4],
                     "public":True,
                     "emailVerified":False,
-                    "login":user[5],
+                    "login":"%s.%s" % (user[1],user[4]) ,
                     "email":user[5]
                   }
       usersDB.insert_one(inputUser)


### PR DESCRIPTION
Switch from using the user's email as the login name as Girder
doesn't like an '@' symbol in the user name