### PR TITLE
Fix prepopulation of License and categories

### DIFF
--- a/web_external/pages/submit/editSubmission.js
+++ b/web_external/pages/submit/editSubmission.js
@@ -13,15 +13,7 @@ import CategoryTemplate from '../home/home_categoryTemplate.pug';
 var editView = View.extend({
     events: {
         'click .filterOption': function (event) {
-            if (this.$('.filterOption:checked').length > 0) {
-                this.$('.filterOption').each(function (index, val) {
-                    val.required = false;
-                });
-            } else {
-                this.$('.filterOption').each(function (index, val) {
-                    val.required = true;
-                });
-            }
+            this._checkCategories();
         },
         'click .issueGen': function (event) {
             this.parentID = event.currentTarget.target;
@@ -113,6 +105,7 @@ var editView = View.extend({
                 for (var catIndx in resp[0].meta.categories) {
                     this.$(`.filterOption[val=${resp[0].meta.categories[catIndx]}]`).attr('checked', true);
                 }
+                this._checkCategories();
                 restRequest({
                     type: 'GET',
                     url: `journal/disclaimers?tag=disclaimer`
@@ -128,6 +121,17 @@ var editView = View.extend({
                 });
             });
         }); // End getting of OTJ Collection value setting
+    },
+    _checkCategories() {
+        if (this.$('.filterOption:checked').length > 0) {
+            this.$('.filterOption').each(function (index, val) {
+                val.required = false;
+            });
+        } else {
+            this.$('.filterOption').each(function (index, val) {
+                val.required = true;
+            });
+        }
     },
     _captureSubmissionInformation() {
         var authors = [];

--- a/web_external/pages/upload/upload.js
+++ b/web_external/pages/upload/upload.js
@@ -125,11 +125,14 @@ var uploadView = View.extend({
                 for (var index in itemResp) {
                     this.$('#uploadTable').append(UploadEntryTemplate({info: itemResp[index]}));
                     this.$('#uploadQuestions').show();
-                    $('#acceptRights').prop('checked', 'checked');
-                    $('#acceptLicense').prop('checked', 'checked');
-                    $('#licenseChoice').val(resp[0].meta['source-license']);
-                    $('#otherLicenseInput').val(resp[0].meta['source-license-text']);
+                    this.$('#acceptRights').prop('checked', 'checked');
+                    this.$('#acceptLicense').prop('checked', 'checked');
+                    this.$('#acceptAttributionPolicy').prop('checked', 'checked');
+                    this.$('#licenseChoice').val(resp[0].meta['source-license']);
+                    this.$('#otherLicenseInput').val(resp[0].meta['source-license-text']);
                 }
+                this._checkForm(resp[0].meta['source-license']);
+                this.submitCheck();
             });
         });
     },


### PR DESCRIPTION
Add a check for the categories selection both on change of filters and on
render of the page.

Ensure that the license form is up-to-date after prepopulating the information
from the revision.  Ensure that the AttributionPolicy is checked by default