### PR TITLE
Add typing to imported files and revisions

### DIFF
--- a/midas_girder_connection.py
+++ b/midas_girder_connection.py
@@ -21,6 +21,28 @@ licenseDict = {
  "6": "BSD",
  "": "Public Domain"
 }
+typeDict = {
+  "0": "GENERAL",
+  "1": "PUBLICATION",
+  "2": "TUTORIAL",
+  "3": "SOFTWARE",
+  "4": "PLUGIN",
+  "5": "DATASET",
+  "": "GENERAL"
+}
+
+filetypeDict = {
+  "1": "THUMBNAIL",
+  "2": "SOURCECODE",
+  "8": "TESTING_SOURCECODE",
+  "3": "PAPER",
+  "4": "DATA",
+  "5": "MISC",
+  "6": "GITHUB",
+  "7": "TECHNICAL",
+  "": "MISC"
+}
+
 discDictionary = {'': {'name': ''}}
 
 def metaDataQuery(cur, entryNo, fieldNo):
@@ -29,6 +51,8 @@ def metaDataQuery(cur, entryNo, fieldNo):
     if returnVal and returnVal[2]:
         if fieldNo == "34":
             return licenseDict[returnVal[2].strip()]
+        if fieldNo == "41":
+            return typeDict[returnVal[2].strip()]
         if fieldNo == "18":
             retArray = []
             # 18 is the list of categories, which has mixed data for languages and VistA packages
@@ -46,6 +70,9 @@ def metaDataQuery(cur, entryNo, fieldNo):
         return returnVal[2]
     if fieldNo == "34":
         return licenseDict['']
+    if fieldNo == "41":
+        return typeDict['']
+
     return ""
 
 def ReadAll( prevAssetDir, baseParent=None, assetStore=None,):
@@ -447,7 +474,7 @@ def ReadAll( prevAssetDir, baseParent=None, assetStore=None,):
                                      "baseParentType":"collection",
                                      "name":bitstream[2],
                                      "meta": {
-                                         "type":bitstream[9]
+                                         "type":filetypeDict(bitstream[9])
                                      },
                                      "baseParentId" : ObjectId(baseParent),
                                      "creatorId":inputRevision["creatorId"],

--- a/web_external/pages/submit/journal_submit.pug
+++ b/web_external/pages/submit/journal_submit.pug
@@ -111,12 +111,12 @@ mixin disclaimerEntry(text)
               tr
                 td
                   select#typeEntry.parsely-validated(required, name="type")
-                    option(value="0") General
-                    option(value="1") Publication
-                    option(value="2") Tutorial
-                    option(value="3") Software
-                    option(value="4") Plugin
-                    option(value="5") Dataset
+                    option(value="GENERAL") General
+                    option(value="PUBLICATION") Publication
+                    option(value="TUTORIAL") Tutorial
+                    option(value="SOFTWARE") Software
+                    option(value="PLUGIN") Plugin
+                    option(value="DATASET") Dataset
               tr
                 td
                   .submission

--- a/web_external/pages/upload/journal_upload.pug
+++ b/web_external/pages/upload/journal_upload.pug
@@ -11,14 +11,14 @@
         You can also upload a logo which will be shown on the article's page
       select#typeFile
         option
-        option(value=1) Thumbnail (Logo)
-        option(value=2) Source Code
-        option(value=3) Paper
-        option(value=4) Data
-        option(value=5) Other
-        option(value=6) Github Repository
-        option(value=7) Major Technique paper for reference
-        option(value=8) Testing Code
+        option(value="THUMBNAIL") Thumbnail (Logo)
+        option(value="SOURCECODE") Source Code
+        option(value="PAPER") Paper
+        option(value="DATA") Data
+        option(value="MISC") Other
+        option(value="GITHUB") Github Repository
+        option(value="TECHNICAL") Major Technique paper for reference
+        option(value="TESTING_SOURCECODE") Testing Code
       br
       br
       #uploadContentBlock

--- a/web_external/pages/upload/upload.js
+++ b/web_external/pages/upload/upload.js
@@ -11,7 +11,6 @@ import MenuBarView from '../../views/menuBar.js';
 import UploadViewTemplate from './journal_upload.pug';
 import UploadEntryTemplate from './journal_upload_entry.pug';
 
-var fileTypes = ['', 'Thumbnail', 'Source', 'Paper', 'Data', 'Other', 'Github', 'Reference', 'Testing'];
 var uploadView = View.extend({
     events: {
         'submit #curateduploadForm': function (event) {
@@ -35,7 +34,7 @@ var uploadView = View.extend({
 
         'change #typeFile': function (event) {
             event.preventDefault();
-            if (event.target.value === '6') {
+            if (event.target.value === 'GITHUB') {
                 $('#githubContentBlock').show();
             } else {
                 $('#githubContentBlock').hide();
@@ -176,7 +175,7 @@ var uploadView = View.extend({
             // upload the information to the submission value
             // show the information in the table
             var subData = {
-                'type': fileTypes[this.$('#typeFile').val().trim()]
+                'type': this.$('#typeFile').val().trim()
             };
             restRequest({
                 type: 'GET',

--- a/web_external/views/download.js
+++ b/web_external/views/download.js
@@ -26,7 +26,7 @@ var downloadView = View.extend({
                 path: `item?folderId=${this.parentId}`
             }).done((itemResp) => {
                 for (var index in itemResp) {
-                    if (itemResp[index].meta.type === 'Paper') {
+                    if (itemResp[index].meta.type === 'PAPER') {
                         this.paperItem = itemResp[index];
                     }
                 }


### PR DESCRIPTION
Ensure that the typing of the file and submissions that are imported
by the script are correctly transcribed into the metadata.

Ensure that all metadata is used and checked as text instead of numbers