### PR TITLE
Fix user requirement of existing comments

### DIFF
--- a/web_external/pages/view/journal_view.pug
+++ b/web_external/pages/view/journal_view.pug
@@ -20,9 +20,10 @@ mixin existingComment(commentInfo)
     a.commentUserName
       | #{commentInfo.name}
     span.commentDate
-    if (user.attributes.admin)
-      a.deleteCommentLink(val=commentInfo.index)
-        | Remove Comment
+    if user
+      if (user.attributes.admin)
+        a.deleteCommentLink(val=commentInfo.index)
+          | Remove Comment
     .commentTextDiv
       span.commentText
         | #{commentInfo.text}


### PR DESCRIPTION
Fix comment display to not throw errors if a user is not logged in. When
generating existing comments, the user is checked for administrator
priviliges, a logged out user would throw an error due to the "null"
user object.