### PR TITLE
Account for "null" reivision updates

### DIFF
--- a/midas_girder_connection.py
+++ b/midas_girder_connection.py
@@ -463,6 +463,8 @@ def ReadAll( prevAssetDir, baseParent=None, assetStore=None,):
           inputRevision["_id"] = ObjectId()
           inputRevision["description"] = revision[4]
           inputRevision["created"] = revision[3]
+          if inputRevision["created"] == None:
+            inputRevision["created"] = row[2]
           print inputRevision['name']
           # Capture the download and view information
           cur.execute("SELECT * FROM statistics_download WHERE item_id="+ str(revision[0]))


### PR DESCRIPTION
In some cases, the update date for a revision comes across as empty:
"0000-00-00 ....".  Account for that by adding the update of the overall
submission in its place.