### PR TITLE
Remove example link from submit page

### DIFF
--- a/web_external/pages/submit/journal_select_issue.pug
+++ b/web_external/pages/submit/journal_select_issue.pug
@@ -22,8 +22,6 @@ mixin issueEntry(info, parName)
           br
           | Don't know how to submit your paper? Visit the
           a(href="#help") help page
-          | or download an
-          a(href="") example
           br
           br
           table(width="70%", border="0")


### PR DESCRIPTION
Remove the link which points to an example submission