### PR TITLE
Extend Girder's user page for Notification setup

### DIFF
--- a/midas_girder_connection.py
+++ b/midas_girder_connection.py
@@ -185,7 +185,12 @@ def ReadAll( prevAssetDir, baseParent=None, assetStore=None,):
                     "public":True,
                     "emailVerified":False,
                     "login":"%s.%s" % (user[1],user[4]) ,
-                    "email":user[5]
+                    "email":user[5],
+                    "notificationStatus": {
+                        'NewSubmissionEmail': user[19],
+                        'NewReviewsEmail': user[20],
+                        'NewCommentEmail': user[21],
+                    }
                   }
       usersDB.insert_one(inputUser)
       userDictionary[user[0]] = inputUser

--- a/web_external/pages/user/journal_notifications_tab.pug
+++ b/web_external/pages/user/journal_notifications_tab.pug
@@ -1,0 +1,31 @@
+#g-account-tab-notifications.tab-pane
+  .g-user-settings-container
+    h3 Notifications
+    form#notificationForm.genericForm(method="post")
+      table(width="100%", height="119px", border = "0px")
+        tbody
+          tr
+            td(height="17px", valign="top")
+              | Receive email when there is a new submission in a new journal:
+              input(type="radio", name="NewSubmissionEmail", value=1, required)
+              | Yes
+              input(type="radio", name="NewSubmissionEmail", value=0)
+              | No
+          tr
+            td(height="17px", valign="top")
+              | Receive email when there is a new review for my publications:
+              input(type="radio", name="NewReviewsEmail", value=1, required)
+              | Yes
+              input(type="radio", name="NewReviewsEmail", value=0)
+              | No
+          tr
+            td(height="17px", valign="top")
+              | Receive email when a comment is posted for any submission:
+              input(type="radio", name="NewCommentEmail", value=1, required)
+              | Yes
+              input(type="radio", name="NewCommentEmail", value=0)
+              | No
+          tr
+            input#submitNotificationForm(type="submit", name="submit", value="Save")
+      br
+      br

--- a/web_external/pages/user/journal_notifications_tab_entry.pug
+++ b/web_external/pages/user/journal_notifications_tab_entry.pug
@@ -1,0 +1,4 @@
+li
+  a(href="#g-account-tab-notifications", data-toggle="tab", name="notifications")
+    i.icon-email
+    | Notifications

--- a/web_external/pages/user/user.js
+++ b/web_external/pages/user/user.js
@@ -1,0 +1,86 @@
+import $ from 'jquery';
+import UserAccountView from 'girder/views/body/UserAccountView';
+import { AccessType } from 'girder/constants';
+import router from 'girder/router';
+import events from 'girder/events';
+import { getCurrentUser } from 'girder/auth';
+import { cancelRestRequests, restRequest } from 'girder/rest';
+import UserAccountTemplate from 'girder/templates/body/userAccount.pug';
+
+import MenuBarView from '../../views/menuBar.js';
+import NotificationTabFormTemplate from './journal_notifications_tab.pug';
+import NotificationTabTemplate from './journal_notifications_tab_entry.pug';
+
+var userView = UserAccountView.extend({
+    events: {
+        'submit #notificationForm': function (event) {
+            event.preventDefault();
+            var params = {
+                'NewSubmissionEmail': this.$('[name="NewSubmissionEmail"]').filter(function (indx, val) { return val.checked; }).val(),
+                'NewReviewsEmail': this.$('[name="NewReviewsEmail"]').filter(function (indx, val) { return val.checked; }).val(),
+                'NewCommentEmail': this.$('[name="NewCommentEmail"]').filter(function (indx, val) { return val.checked; }).val()
+            };
+            this.user.set({'notificationStatus': params});
+            restRequest({
+                type: 'PUT',
+                url: 'journal/user',
+                contentType: 'application/json',
+                data: JSON.stringify(this.user),
+                error: null
+            }).done((resp) => {
+                events.trigger('g:alert', {
+                    icon: 'ok',
+                    text: 'Information Saved.',
+                    type: 'success',
+                    timeout: 4000
+                });
+            });
+        }
+
+    },
+
+    initialize: function (settings) {
+        this.user = getCurrentUser();
+        this.isCurrentUser = getCurrentUser();
+
+        this.model = this.user;
+
+        if (!this.user || this.user.getAccessLevel() < AccessType.WRITE) {
+            router.navigate('users', {trigger: true});
+            return;
+        }
+
+        cancelRestRequests('fetch');
+
+        this.render();
+        // Remove the API keys tab from the user view
+    },
+
+    render: function () {
+        if (getCurrentUser() === null) {
+            router.navigate('users', {trigger: true});
+            return;
+        }
+
+        this.$el.html('<div id="headerBar"></div><div class="Wrapper"><div class="Content">' + UserAccountTemplate({
+            user: this.model,
+            isCurrentUser: this.isCurrentUser,
+            getCurrentUser: getCurrentUser,
+            temporaryToken: this.temporary
+        }) + '</div></div>');
+        new MenuBarView({ // eslint-disable-line no-new
+            el: this.$el,
+            parentView: this
+        });
+        this.$('[name="apikeys"]').parent().remove();
+        this.$('.g-account-tabs').append(NotificationTabTemplate());
+        this.$('.tab-content').append(NotificationTabFormTemplate());
+        var notifications = this.user.attributes.notificationStatus;
+        Object.keys(this.user.attributes.notificationStatus).forEach(function (d) {
+            $(`[name=${d}][value=${notifications[d]}]`).prop('checked', true);
+        });
+        return this;
+    }
+});
+
+export default userView;

--- a/web_external/routes.js
+++ b/web_external/routes.js
@@ -20,6 +20,7 @@ import EditJournalView from './views/editJournal';
 import manageHelpView from './views/manageHelp';
 import FeedBackView from './views/feedback';
 import EditGroupUsersView from './views/groupUsers.js';
+import userView from './pages/user/user.js';
 
 // Clear all of the existing routes, which will always added by Girder
 Backbone.history.handlers = [];
@@ -39,6 +40,11 @@ router.route('admin/categories', 'adminCategories', function () {
 // Submission related pages
 router.route('submission/new', 'submissionInfo', function () {
     testUserAccess(submitView, {id: 'new'}, true, false);
+});
+
+// user profile page
+router.route('plugins/user/:id/edit', 'submissionInfo', function (id) {
+    testUserAccess(userView, {id: id}, true, false);
 });
 
 router.route('plugins/journal/submission/:id/new', 'submissionInfo', function (id) {

--- a/web_external/templates/journal_menu_bar.pug
+++ b/web_external/templates/journal_menu_bar.pug
@@ -59,14 +59,13 @@
             | New Publication
         if user
           li#profileLink
-            a(href='/#user/' + user.id) My Profile
+            a.submm(href='#plugins/user/' + user.id + '/edit') My Profile
             #userOptionsDiv
               ul#userOptionsList
                 li
-                  // TODO: implement this route
                   a.submm(href='#?query="creatorId":"'+user.id+'"') My Publications
                 li
-                  a.submm(href='/#useraccount/' + user.id + '/info') Edit Profile
+                  a.submm(href='#plugins/user/' + user.id + '/edit') Edit Profile
           if user.attributes.admin
             li#adminLink
               a(href="") Admin


### PR DESCRIPTION
Extend and alter Girder's user profile page to add a tab which allows
the user to select from the types of notifications