### PR TITLE
Add submission survey capability

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -8,5 +8,5 @@
             "plugin": "web_client/main.js",
             "app": "web_external/main.js"
         }
-  }
+    }
 }

--- a/server/mail_templates/tech_journal_approval.mako
+++ b/server/mail_templates/tech_journal_approval.mako
@@ -7,4 +7,9 @@ A new submission has been added to the OSEHRA Technical Journal
 <b>Authors:</b>${authors}</br>
 <b>Abstract:</b>${abstract}</br>
 </div>
+
+
+Review the results of the survey
+<a href="http://localhost:8080/tech_journal#plugins/journal/submission/${id}/survey"> here</a>.
+
 <%include file="tech_journal_footer.mako"/>

--- a/tech_journal_tasks/tech_journal_tasks/tasks.py
+++ b/tech_journal_tasks/tech_journal_tasks/tasks.py
@@ -1,12 +1,71 @@
 from girder_worker.app import app
+from girder.models.folder import Folder
+from girder.models.item import Item
+from girder.models.file import File
 import os
+import re
 import urllib
+import zipfile
+import mimetypes
+
+from subprocess import call
+
+
+Journal_SURVEY_EXPRESSIONS = (("Do not [Re]*distribute",[]),
+  ("Copyright [0-9\-]*",[]),
+  ("(Released|Licensed) ",[]),
+  ("All rights reserved",[]),
+  ("Deriv[atived]+",[])
+)
+
+Journal_FILE_EXCLUDES = (".dat", ".dll", ".DAT", ".exe", ".EXE", ".mdf", ".pdb", ".class", ".jpeg",
+    ".jpg",".png",".gif",".bmp",".docx",".pdf",".vsd",".doc", ".xls", ".xlsx", ".ppt", ".pptx",
+    ".db",".xml",".XML")
+Journal_UNZIP_EXCLUDES= (".EAP",".dll",".docx")
+
+def checkFile(fh, outline):
+      while True:
+        line = fh.read(1024)
+        if not line:
+            break
+      #for line in fh.read().split('\n'):
+        for entry in Journal_SURVEY_EXPRESSIONS:
+          if re.search(entry[0], line, re.I):
+            entry[1].append((outline,line))
+
 
 @app.task
 def processGithub(path, **kwargs):
   githubArray = path.split("/")
   url = "https://github.com/%s/%s/archive/master.zip" % (githubArray[3],githubArray[4])
   openedPage = urllib.urlretrieve(url,"githubzip.zip")
-  print openedPage
   return os.path.join(os.getcwd(),"githubzip.zip")
-
+  
+@app.task
+def surveySubmission(folder, **kwargs):
+  for item in Folder().childItems(folder):
+    for uploadedFile in Item().childFiles(item):
+      with File().open(uploadedFile) as fh:
+        outline = uploadedFile['name']
+        filename, file_extension = os.path.splitext(outline)
+        if file_extension in Journal_FILE_EXCLUDES:
+          continue
+        if zipfile.is_zipfile(fh) and (not file_extension in Journal_UNZIP_EXCLUDES):
+          with zipfile.ZipFile(fh) as zippedFile:
+            for file in zippedFile.namelist():
+              zipfilename, zipfile_extension = os.path.splitext(file)
+              if not zipfile_extension in Journal_FILE_EXCLUDES:
+                checkFile(zippedFile.open(file),"TEST")
+        else:
+          checkFile(fh, outline)
+  with open(os.path.join("SurveyResult.txt"),"w") as outfile:
+    outfile.write("Begin Report")
+    for entry in Journal_SURVEY_EXPRESSIONS:
+      if len(entry[1]):
+        outfile.write("**********************\nFound results for\n")
+        outfile.write(entry[0]+"\n")
+        outfile.write("**********************\n")
+        for item in entry[1]:
+          outfile.write(item[0]+"\n     "+ item[1]+"\n")
+    outfile.write("\n\nEnd Report")
+  return os.path.join(os.getcwd(),"SurveyResult.txt")

--- a/web_external/pages/survey/journal_survey.pug
+++ b/web_external/pages/survey/journal_survey.pug
@@ -1,0 +1,10 @@
+#headerBar
+.Wrapper
+  .Content
+    div
+      br
+      div(align="center")
+        font(size="+1")
+          strong View Survey Results
+      br
+      pre #{info}

--- a/web_external/pages/survey/survey.js
+++ b/web_external/pages/survey/survey.js
@@ -1,0 +1,31 @@
+import View from 'girder/views/View';
+import { restRequest } from 'girder/rest';
+
+import MenuBarView from '../../views/menuBar.js';
+import SurveyViewTemplate from './journal_survey.pug';
+
+var surveyView = View.extend({
+
+    events: {
+    },
+    initialize: function (options) {
+        restRequest({
+            type: 'GET',
+            url: `journal/${options.id}/survey`
+        }).done((totalDetails) => {
+            this.render(totalDetails);
+        });
+    },
+    render: function (details) {
+        this.$el.html(SurveyViewTemplate({'info': details}));
+        new MenuBarView({ // eslint-disable-line no-new
+            el: this.$el,
+            parentView: this,
+            searchBoxVal: '',
+            appCount: 0
+        });
+        return this;
+    }
+});
+
+export default surveyView;

--- a/web_external/routes.js
+++ b/web_external/routes.js
@@ -21,6 +21,7 @@ import manageHelpView from './views/manageHelp';
 import FeedBackView from './views/feedback';
 import EditGroupUsersView from './views/groupUsers.js';
 import userView from './pages/user/user.js';
+import surveyView from './pages/survey/survey.js';
 
 // Clear all of the existing routes, which will always added by Girder
 Backbone.history.handlers = [];
@@ -78,6 +79,9 @@ router.route('plugins/journal/submission/:id/upload/revision', 'uploadFiles', fu
 });
 router.route('plugins/journal/submission/:id/upload/edit', 'uploadFiles', function (id) {
     testUserAccess(uploadView, {id: id, newSub: false, NR: false}, true, false);
+});
+router.route('plugins/journal/submission/:id/survey', 'uploadFiles', function (id) {
+    testUserAccess(surveyView, {id: id}, true, true);
 });
 
 // Page to view each individual submission


### PR DESCRIPTION
Add a new girder worker task which will examine the submission for
licensing and other simple text strings.  It should save the report to
be viewed later by an administrator.

Add the link to the survey to the approval email.