### PR TITLE
Stop redirecting to home after every login and logout

### DIFF
--- a/web_external/routes.js
+++ b/web_external/routes.js
@@ -171,7 +171,8 @@ function testUserAccess(view, args, needsUser, needsAdmin) {
         events.trigger('g:navigateTo', view, args, {layout: Layout.EMPTY});
     } else {
         if (!user) {
-            window.location.href = '#?dialog=login';
+            window.history.back();
+            window.location += '?dialog=login';
         }
     }
 }

--- a/web_external/views/menuBar.js
+++ b/web_external/views/menuBar.js
@@ -13,7 +13,7 @@ var MenuBarView = View.extend({
                 type: 'DELETE',
                 path: 'user/authentication'
             }).done((resp) => {
-                window.location.href = '';
+                window.location.reload(true);
             });
         },
         'mouseenter #profileLink': function (event) {


### PR DESCRIPTION
Ensure that the most recent page in history, via back(), is utilized
when a page is reached that requires the user to login.

Reload the page when the user logs out, taking advantage of the "back"
feature above to find a page that can be displayed.