### PR TITLE
Add oauth plugin dependency

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "name": "Tech Journal plugin",
     "description": "An attempt to generate a plug in for a Tech Journal module",
     "version": "0.0.1",
-    "dependencies": ["curation","worker","jobs"],
+    "dependencies": ["curation","worker","jobs","oauth"],
     "webpack": {
         "main": {
             "plugin": "web_client/main.js",


### PR DESCRIPTION
The html webroot depends on this plugin, but is not automatically enabled.