### PR TITLE
Re-enable the plugin config page

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,5 +2,10 @@
     "name": "Tech Journal plugin",
     "description": "An attempt to generate a plug in for a Tech Journal module",
     "version": "0.0.1",
-    "dependencies": ["curation"]
+    "dependencies": ["curation"],
+    "webpack": {
+        "main": {
+            "plugin":"web_client/main.js"
+        }
+    }
 }


### PR DESCRIPTION
Add the webpack call for the web-client page back to the plugin.json file.
This will allow us to set a default Journal ID and other eventually important
information.