### PR TITLE
Add revision links on filtering

### DIFF
--- a/girder-tech-journal-gui/src/templates/journal_index_entry.pug
+++ b/girder-tech-journal-gui/src/templates/journal_index_entry.pug
@@ -19,7 +19,7 @@ mixin searchEntry(info,approveLink)
             if approveLink
               a.resourceLink(href="#plugins/journal/submission/"+ info.currentRevision._id+"/approve")
             else
-              a.resourceLink(href="#view/"+ info.meta.submissionNumber)
+              a.resourceLink(href="#view/"+ info.meta.submissionNumber +"/" + info.currentRevision.meta.revisionNumber)
             span.ResultTitle.
               #{info.name}
           .ResultLicense.


### PR DESCRIPTION
Ensure that when a category or other filter is shown, that the
latest revision to match the filter is used as the link instead of
the latest revision in time.