### PR TITLE
Add "required" fields to Feedback form

### DIFF
--- a/girder-tech-journal-gui/src/pages/feedback/feedback.js
+++ b/girder-tech-journal-gui/src/pages/feedback/feedback.js
@@ -2,8 +2,8 @@ import View from 'girder/views/View';
 import events from 'girder/events';
 import { restRequest } from 'girder/rest';
 
-import MenuBarView from './menuBar.js';
-import FeedbackViewTemplate from '../templates/journal_help_feedback.pug';
+import MenuBarView from '../../views/menuBar.js';
+import FeedbackViewTemplate from './journal_help_feedback.pug';
 
 var FeedbackView = View.extend({
 

--- a/girder-tech-journal-gui/src/pages/feedback/journal_help_feedback.pug
+++ b/girder-tech-journal-gui/src/pages/feedback/journal_help_feedback.pug
@@ -19,7 +19,7 @@
                   .caption(style="width:100%;")
             tr
               td
-                input#Title.textbox.parsley-validated(value="", data-required="true", data-type="email", size='65', name='email')
+                input#Title.textbox.parsley-validated(value="", required, data-type="email", size='65', name='email')
             tr
               td
                 .submission
@@ -27,10 +27,9 @@
                     | Location of the problem
                   .caption(style="width:100%;")
                     | Give an address (URL) if possible
-                  
             tr
               td
-                input#Where.textbox.parsley-validated(value="", data-required="true", size='65', name='where')
+                input#Where.textbox.parsley-validated(value="", size='65', name='where')
             tr
               td
                 .submission
@@ -41,7 +40,7 @@
                     | Please be as specific as possible in your report
             tr
               td
-                input#Summary.textbox.parsley-validated(value="", data-required="true", size='65', name='what')
+                textarea#Summary.textbox.parsley-validated(value="", required, style='width: 280px;', name='what')
             tr
               td
                 div(align='right')

--- a/girder-tech-journal-gui/src/routes.js
+++ b/girder-tech-journal-gui/src/routes.js
@@ -19,7 +19,7 @@ import manageJournalView from './views/manageJournal';
 import EditIssueView from './views/editIssue';
 import EditJournalView from './views/editJournal';
 import manageHelpView from './views/manageHelp';
-import FeedBackView from './views/feedback';
+import FeedBackView from './pages/feedback/feedback.js';
 import EditGroupUsersView from './views/groupUsers.js';
 import userView from './pages/user/user.js';
 import surveyView from './pages/survey/survey.js';


### PR DESCRIPTION
Move Feedback pages to a pages subdirectory and ensure that the
email address and description fields are correctly marked as required.