### PR TITLE
Fix Citation export

### DIFF
--- a/girder-tech-journal-gui/src/pages/view/view.js
+++ b/girder-tech-journal-gui/src/pages/view/view.js
@@ -80,7 +80,7 @@ var submissionView = View.extend({
             this.$('.citationDisplay').text('');
             restRequest({
                 type: 'GET',
-                url: `journal/${this.displayId}/citation/${this.$('.citOption:selected').val()}`
+                url: `journal/${this.revisionId}/citation/${this.$('.citOption:selected').val()}`
             }).done((citationText) => {
                 this.$('.citationDisplay').show();
                 this.$('.citationDisplay').text(citationText);


### PR DESCRIPTION
Fix the citation export to use the revision's Girder ID and not the one
of the submission.