### PR TITLE
Reintroduce "worker" dependency

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "name": "Tech Journal plugin",
     "description": "An attempt to generate a plug in for a Tech Journal module",
     "version": "0.0.1",
-    "dependencies": ["curation"],
+    "dependencies": ["curation", "worker"],
     "webpack": {
         "main": {
             "plugin":"web_client/main.js"


### PR DESCRIPTION
The GitHub and Survey capability need the "Worker" functionality to be
loaded in the Girder instance. Add it back to the "dependencies"