### PR TITLE
Remove extra spaces from the "text" search terms

### DIFF
--- a/girder-tech-journal-gui/src/pages/home/home.js
+++ b/girder-tech-journal-gui/src/pages/home/home.js
@@ -216,6 +216,7 @@ const HomePage = View.extend({
                         // being used as a regex itself, which is not what we
                         // want.
                         searchVal = searchVal.replace('\\', '\\\\');
+                        searchVal = searchVal.replace(' ', '');
                         ['[', '\\\\', '^', '$', '.', '|', '?', '*', '+', '(', ')'].forEach((ch) => {
                             searchVal = searchVal.replace(ch, `\\\\${ch}`);
                         });


### PR DESCRIPTION
Replace any found spaces in the text string which has made it through
the other parsing.