### PR TITLE
Empty issueDetails before creating display

### DIFF
--- a/girder-tech-journal-gui/src/pages/submit/submit.js
+++ b/girder-tech-journal-gui/src/pages/submit/submit.js
@@ -52,6 +52,7 @@ var SubmitView = View.extend({
         },
         'click #showDetails': function (event) {
             this.targetIssueID = event.currentTarget.target;
+            this.$('#issueDetails').empty();
             restRequest({
                 method: 'GET',
                 url: `folder/${this.targetIssueID}`


### PR DESCRIPTION
When a "Show Details" button is clicked for an object, ensure that
the previous set of details is removed.

Fixes #99 