### PR TITLE
Ensure Citation text doesn't inherit white font color

### DIFF
--- a/girder-tech-journal-gui/src/stylesheets/view.index.styl
+++ b/girder-tech-journal-gui/src/stylesheets/view.index.styl
@@ -105,6 +105,9 @@
 
 */
 
+.citationDisplay
+  color #666
+
 .publication
   position relative
   padding-bottom 30px


### PR DESCRIPTION
Explicitly give the citation textarea a darker font color to show up
on the white background.