### PR TITLE
Fix logo manipulation on "Approve" page

### DIFF
--- a/girder-tech-journal-gui/src/views/manageApproval.js
+++ b/girder-tech-journal-gui/src/views/manageApproval.js
@@ -1,5 +1,5 @@
 import View from '@girder/core/views/View';
-import { restRequest } from '@girder/core/rest';
+import { restRequest, apiRoot } from '@girder/core/rest';
 
 import MenuBarView from './menuBar.js';
 import ApprovalViewTemplate from '../templates/journal_admin_approval.pug';
@@ -37,12 +37,14 @@ var manageApprovalView = View.extend({
         this.$('.SearchResults').html(IndexEntryViewTemplate({
             info: {
                 'submissions': subData,
-                'approveLink': true,
-                'logos': {
-                    'default': PlaceholderLogoURL,
-                    'certified': CertificationLogoURL
-                }
+                'approveLink': true
+            },
+            root: apiRoot,
+            'logos': {
+                'default': PlaceholderLogoURL,
+                'certified': CertificationLogoURL
             }
+
         }));
         new MenuBarView({ // eslint-disable-line no-new
             el: this.$('#headerBar'),

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -491,6 +491,9 @@ class TechJournal(Resource):
                                                         ))
                 if len(submissionInfo):
                     submission['currentRevision'] = submissionInfo[-1]
+                submission['currentRevision']['logo'] = self.getLogo(
+                    id=submission['currentRevision']['_id'],
+                    params=params)
                 if "curation" in submission:
                     if submission['curation']['status'] == "REQUESTED":
                         totalData.append(submission)


### PR DESCRIPTION
Ensure that the revision is checked for logos before displaying
the list on the approval page.  Ensure that the logo information
is not a subset of "info"