### PR TITLE
Fix Submit page

### DIFF
--- a/girder-tech-journal-gui/src/pages/upload/journal_upload.pug
+++ b/girder-tech-journal-gui/src/pages/upload/journal_upload.pug
@@ -14,7 +14,7 @@
         You can also upload a logo which will be shown on the article's page
       label(for="typeFile") What type of file do you want to upload?
       select#typeFile(name="typeFile")
-        option
+        option(disabled=true, selected)
         option(value="THUMBNAIL") Thumbnail (Logo)
         option(value="SOURCECODE") Source Code
         option(value="PAPER") Paper

--- a/girder-tech-journal-gui/src/pages/upload/upload.js
+++ b/girder-tech-journal-gui/src/pages/upload/upload.js
@@ -179,13 +179,14 @@ var uploadView = View.extend({
             var subData = {
                 'type': this.$('#typeFile').val().trim()
             };
+            var fileID = retInfo.files[0].id;
             restRequest({
                 method: 'GET',
-                url: `item?folderId=${this.parentId}&name=${retInfo.files[0].name}`
-            }).done((resp) => {
+                url: `file/${fileID}`
+            }).done((fileInfo) => {
                 restRequest({
                     method: 'PUT',
-                    url: `item/${resp[0]._id}/metadata`,
+                    url: `item/${fileInfo['itemId']}/metadata`,
                     contentType: 'application/json',
                     data: JSON.stringify(subData),
                     error: null

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -656,7 +656,7 @@ class TechJournal(Resource):
             'status': 'REQUESTED'
         }
         folder['curation'] = DEFAULTS
-        folder['public'] = False
+        folder['public'] = True
         self.model('folder').save(folder)
         parentFolder = self.model('folder').load(folder['parentId'], force=True)
         targetFolder = self.model('folder').load(parentFolder['meta']['targetIssue'], force=True)
@@ -668,7 +668,7 @@ class TechJournal(Resource):
         text = mail_utils.renderTemplate('tech_journal_approval.mako', data)
         sendEmails(User().getAdmins(), 'New Submission - Pending Approval', text)
         movedFolder['curation'] = DEFAULTS
-        parentFolder['public'] = False
+        parentFolder['public'] = True
         self.model('folder').save(movedFolder)
         newItem = self.model("item").createItem(name="Survey Result",
                                                 creator=self.getCurrentUser(),
@@ -692,6 +692,8 @@ class TechJournal(Resource):
             'enabled': False,
             'status': 'APPROVED'}
         parentFolder = self.model('folder').load(folder['parentId'], force=True)
+        folder['public'] = True
+        parentFolder['public'] = True
         getFunc = getattr(ModelImporter.model('journal', 'tech_journal'), 'get')
         if getFunc("tech_journal.use_review", {}):
             # Use the folder's information to find review objects to


### PR DESCRIPTION
Ensure that the submission doesn't accept an upload of "" type
Ensure that the submissions are always public when approving and
submitting for approval

Ensure that files with the same name do not overwrite metadata by
no longer searching by name but by ID of uploaded file.