### PR TITLE
Check for attachFileValue to exist

### DIFF
--- a/girder-tech-journal-gui/src/pages/review/review.js
+++ b/girder-tech-journal-gui/src/pages/review/review.js
@@ -30,7 +30,7 @@ var reviewView = View.extend({
             }, this);
             this.$('#templateQuestions').empty();
             Object.keys(questionList).forEach(function (questionIndex) {
-                if (questionList[questionIndex].attachfileValue !== '') {
+                if (questionList[questionIndex].hasOwnProperty('attachFileValue') && questionList[questionIndex].attachfileValue !== '') {
                     restRequest({
                         type: 'GET',
                         url: `file/${questionList[questionIndex].attachfileValue}`


### PR DESCRIPTION
Check for  attachFileValue to exist before attempting to check if it
is an empty string.  This will prevent calls to query for an undefined
file ID