### PR TITLE
Disable elements on non-matching reviewers

### DIFF
--- a/girder-tech-journal-gui/src/pages/review/review.js
+++ b/girder-tech-journal-gui/src/pages/review/review.js
@@ -39,8 +39,9 @@ var reviewView = View.extend({
                         questionList[questionIndex].attachfileURL = `${apiRoot}/file/${attachFileDetails._id}/download`;
                         this.$('#templateQuestions').append(
                             QuestionTemplate({'question': questionList[questionIndex],
-                                index: questionIndex,
-                                'type': this.type
+                                'index': questionIndex,
+                                'type': this.type,
+                                'isDisabled': this.disablePage
                             })
                         );
                     });
@@ -48,7 +49,8 @@ var reviewView = View.extend({
                     this.$('#templateQuestions').append(
                         QuestionTemplate({'question': questionList[questionIndex],
                             index: questionIndex,
-                            'type': this.type
+                            'type': this.type,
+                            'isDisabled': this.disablePage
                         })
                     );
                 }
@@ -83,6 +85,7 @@ var reviewView = View.extend({
     render: function (options) {
         this.type = options['type'];
         this.reviewIndex = options['index'];
+        var user = getCurrentUser();
         restRequest({
             type: 'GET',
             url: `journal/${options['id']}/details`
@@ -90,11 +93,10 @@ var reviewView = View.extend({
             this.revData = totalDetails[0];
             this.returnURL = `#view/${totalDetails[1].meta.submissionNumber}/${this.revData.meta.revisionNumber}`;
             this.parentId = totalDetails[1]._id;
+            this.disablePage = true;
             var templateData = {
                 'name': totalDetails[1]['name'],
-                'user': getCurrentUser(),
-                'description': totalDetails[1]['description'],
-                'currentUser': getCurrentUser()
+                'description': totalDetails[1]['description']
             };
             if (this.type === 'peer') {
                 if (this.reviewIndex === 'new') {
@@ -104,6 +106,10 @@ var reviewView = View.extend({
                     this.reviewData = this.revData.meta.reviews[this.type].reviews[this.reviewIndex];
                 }
                 templateData['review'] = this.reviewData;
+                if (user) {
+                    this.disablePage = !((templateData['review']['user'] === user) || (user.attributes.admin));
+                }
+                templateData['isDisabled'] = this.disablePage;
                 this.$el.html(PeerReviewTemplate(templateData));
                 this.processReviewFunc = this._processPeerReview;
             } else {
@@ -114,6 +120,11 @@ var reviewView = View.extend({
                     this.reviewData = this.revData.meta.reviews[this.type].reviews[this.reviewIndex];
                 }
                 templateData['review'] = this.reviewData;
+                if (user) {
+                    this.disablePage = !((templateData['review']['user'] === user) || (user.attributes.admin));
+                }
+                templateData['isDisabled'] = this.disablePage;
+                this.$el.html(PeerReviewTemplate(templateData));
                 this.$el.html(FinalReviewTemplate(templateData));
                 this.processReviewFunc = this._processFinalReview;
             }

--- a/girder-tech-journal-gui/src/pages/review/review_final.pug
+++ b/girder-tech-journal-gui/src/pages/review/review_final.pug
@@ -22,17 +22,15 @@
                 h4 Summary
                 #summaryTable
                 h4 Comments
-                textarea#globalComment #{review.questions.list.comment}
+                textarea#globalComment(disabled=isDisabled) #{review.questions.list.comment}
                 h4 Recommended Certification Level
-                  select#certificationLevel
+                  select#certificationLevel(disabled=isDisabled)
                     for i in ['1','2','3','4']
                       if review.questions.list.certificationLevel === i
                         option(value=i, selected) #{i}
                       else
                         option(value=i) #{i}
-                if user
-                  if (review['user'] === user) || (user.attributes.admin)
-                    input#saveReview(type="button", value="Save")
+                input#saveReview(type="button", value="Save", disabled=isDisabled)
             td#tdRightPanel
               #divRightPanel
                 h4 Topics

--- a/girder-tech-journal-gui/src/pages/review/review_peer.pug
+++ b/girder-tech-journal-gui/src/pages/review/review_peer.pug
@@ -23,17 +23,15 @@
                 h4 Summary
                 #summaryTable
                 h4 Comments
-                textarea#globalComment #{review.questions.list.comment}
+                textarea#globalComment(disabled=isDisabled) #{review.questions.list.comment}
                 h4 Recommended Certification Level
-                  select#certificationLevel
+                  select#certificationLevel(disabled=isDisabled)
                     for i in ['1','2','3','4']
                       if review.questions.list.certificationLevel === i
                         option(value=i, selected) #{i}
                       else
                         option(value=i) #{i}
-                if user
-                  if (review['user'] === user) || (user.attributes.admin)
-                    input#saveReview(type="button", value="Save")
+                    input#saveReview(type="button", value="Save", disabled=isDisabled)
             td#tdRightPanel
               #divRightPanel
                 h4 Topics

--- a/girder-tech-journal-gui/src/pages/review/review_questionEntry.pug
+++ b/girder-tech-journal-gui/src/pages/review/review_questionEntry.pug
@@ -6,7 +6,7 @@ else
 - var questionSize = Object.keys(reviewOptions).length
 .questionObject(value=index)
   .selectMultipleWrapper
-    select.questionVal(size=questionSize)
+    select.questionVal(size=questionSize, disabled=isDisabled)
       for i in Object.keys(reviewOptions)
         if question.value.indexOf(i) !== -1
           option(value=i, selected) #{reviewOptions[i]}
@@ -19,8 +19,8 @@ else
         td(style="width:100px") Comment
         if question.comment
           td
-            textarea.questionComment #{question.commentValue}
-  if question.attachfile === 1
+            textarea.questionComment(disabled=isDisabled) #{question.commentValue}
+  if (question.attachfile === 1) && (!isDisabled)
     .uploadWrapper
       table
         tbody


### PR DESCRIPTION
Disable the input elements for established reviews when the current
user does not match the user of the review or the user is not an
administrator