### PR TITLE
Add public "Evidence" upload to review

### DIFF
--- a/girder-tech-journal-gui/src/pages/view/view.js
+++ b/girder-tech-journal-gui/src/pages/view/view.js
@@ -97,7 +97,6 @@ var submissionView = View.extend({
             url: `journal/submission/${this.displayId}/revision`
         }).done((revisionsResp) => {
             revisions = revisionsResp;
-            console.log(revisions);
             restRequest({
                 method: 'GET',
                 url: `journal/submission/${this.displayId}`

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -178,6 +178,7 @@ class TechJournal(Resource):
         self.route('GET', ('submission', ':id'), self.getSubmission)
         self.route('GET', ('submission', ':id', 'revision'), self.getRevisions)
         self.route('GET', ('review', ':id', 'directory'), self.getUploadDirectory)
+        self.route('POST', ('review', ':id', 'upload'), self.uploadEvidence)
         self.route('POST', ('submission', 'number'), self.getNewSubmissionNumber)
         self.route('POST', ('submission', ':submission', 'number'), self.getNewRevisionNumber)
 
@@ -381,6 +382,24 @@ class TechJournal(Resource):
                                          force=True)
         issue = self.model('folder').load(info['parentId'], force=True)
         return issue['meta']['reviewUploadDir']
+
+    @access.public(scope=TokenScope.DATA_READ)
+    @loadmodel(model='folder', level=AccessType.READ)
+    @describeRoute(
+        Description('Place the file information in')
+        .errorResponse('Test error.')
+        .errorResponse('Read access was denied on the issue.', 403)
+    )
+    def uploadEvidence(self, folder, params):
+        json = self.getBodyJson()
+        upload = self.model('upload').createUpload(self.getCurrentUser(),
+                                                   json['name'],
+                                                   'folder',
+                                                   folder,
+                                                   json['size'],
+                                                   json['type']
+                                                   )
+        return upload
 
     @access.public(scope=TokenScope.DATA_READ)
     @describeRoute(


### PR DESCRIPTION
Ensure that a signed-in user is able to upload evidence files to the
"Review Files" directory of each issue.  This requires an override
of the UploadWidget and a new API call to create the proper item to
upload to.