### PR TITLE
Add quotes for >1 word categories

### DIFF
--- a/girder-tech-journal-gui/src/pages/home/home.js
+++ b/girder-tech-journal-gui/src/pages/home/home.js
@@ -105,7 +105,7 @@ const HomePage = View.extend({
                             var queryString = decodeURI(window.location.hash.substring(8));
                             if (queryString.indexOf('category') !== -1) {
                                 var categoryVal = queryString.substring(13, queryString.length - 2);
-                                this.$(`.filterOption[val=${categoryVal}]`)[0].checked = true;
+                                this.$(`.filterOption[val="${categoryVal}"]`)[0].checked = true;
                             } else if (window.location.hash.indexOf('issueId') !== -1) {
                                 issueVal = window.location.hash.split('=')[1];
                             } else if ($('#live_search').val().indexOf(queryString) === -1) {


### PR DESCRIPTION
Ensure that categories like "Electronic Signature" are correctly enclosed
for querying from the main page.