### PR TITLE
Change value used to ensure submissions are captured

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -581,7 +581,7 @@ class TechJournal(Resource):
                 else:
                     textArg = {"name": {"$regex": "Code in Flight", "$options": "i"}}
                 filterParams['Code'].remove("is_cif")
-        textArg["meta"] = {'$exists': True}
+        textArg["meta.submissionNumber"] = {'$gte': "0"}
         for issue in issues:
             testInfo = list(self.model('folder').childFolders(parentType='folder',
                                                               parent=issue,


### PR DESCRIPTION
Change the filtered submissions to check for a submissionNumber before
including it in the list of filters.  This should prevent the "Review Files"
folders from being included.