### PR TITLE
Fix download insertion to match imported values

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1077,9 +1077,13 @@ class TechJournal(Resource):
                                                                    value=value, tag=params['tag'])
 
     def _onDownloadFileComplete(self, event):
+        folder = self.model('folder').load(event.info['id'],
+                                           user=self.getCurrentUser(), force=True)
+        parentInfo = self.model('folder').load(folder['parentId'],
+                                               user=self.getCurrentUser(), force=True)
         self.download_statistics.save({
             'date': datetime.datetime.now(),
-            'item_id': event.info['id']
+            'item_id': ObjectId(parentInfo['_id'])
         })
 
     def _onPageView(self, event):


### PR DESCRIPTION
Ensure the item_ID is an ObjectId object and that the value used is
the value of the submission, not that of the revision.