### PR TITLE
Add "search retention" to main page

### DIFF
--- a/girder-tech-journal-gui/src/pages/home/home.js
+++ b/girder-tech-journal-gui/src/pages/home/home.js
@@ -122,6 +122,15 @@ const HomePage = View.extend({
                             }
                         }
                         this.$(`.issueButton[key='${issueVal}']`).addClass(' issueSelected');
+                        if (window.query !== undefined && window.query !== '') {
+                            // Set existing values:
+                            var lastSearch = JSON.parse('{' + window.query + '}');
+                            Object.keys(lastSearch).forEach(function (category) {
+                                lastSearch[category].forEach(function (value) {
+                                    this.$('.' + category + '[val="' + value + '"]').prop('checked', true);
+                                }, this);
+                            }, this);
+                        }
                         this.buildSearch(this.collectionID, 0);
                     }); // End getting of OTJ Collection value setting
                 }
@@ -168,6 +177,7 @@ const HomePage = View.extend({
         this.querySubmissions(this.collectionID, queryString, startIndex);
     },
     querySubmissions: function (collection, queryString, startIndex) {
+        window.query = queryString;
         restRequest({
             method: 'GET',
             url: `journal/${collection}/search?query={` + encodeURIComponent(queryString) + '}'

--- a/girder-tech-journal-gui/src/pages/home/home_categoryTemplate.pug
+++ b/girder-tech-journal-gui/src/pages/home/home_categoryTemplate.pug
@@ -4,7 +4,7 @@ mixin catEntry(val)
   li.filterEntry
     - var hash = md5('category' + val);
     label.dynatree-title(for=hash)
-      input.filterOption(val=val, id=hash, type="checkbox")
+      input.filterOption(val=val, id=hash, type="checkbox", class=catName)
       | #{val}
 
 .treeEntry

--- a/girder-tech-journal-gui/src/pages/home/journal_main_OV_filter.pug
+++ b/girder-tech-journal-gui/src/pages/home/journal_main_OV_filter.pug
@@ -1,10 +1,10 @@
 .treeEntry
-  h4 OSEHRA VistA
+  h4 OSEHRA
   .categoryTree
     ul.dynatree-container
       li.filterEntry
-        input.filterOption(val="core", type="checkbox")
+        input.OSEHRA.filterOption(val="core", type="checkbox")
         a.dynatree-title(href="#") Core
       li.filterEntry
-        input.filterOption(val="certified", type="checkbox")
+        input.OSEHRA.filterOption(val="certified", type="checkbox")
         a.dynatree-title(href="#") Certified Component

--- a/girder-tech-journal-gui/src/pages/home/journal_main_code_filter.pug
+++ b/girder-tech-journal-gui/src/pages/home/journal_main_code_filter.pug
@@ -7,15 +7,15 @@
       li.filterEntry
         - var hash = md5('code' + 'has_test_code');
         label.dynatree-title(for=hash)
-          input.filterOption(val="has_test_code", id=hash, type="checkbox")
+          input.Code.filterOption(val="has_test_code", id=hash, type="checkbox")
           | With testing code
       li.filterEntry
         - var hash = md5('code' + 'has_code');
         label.dynatree-title(for=hash)
-          input.filterOption(val="has_code", id=hash, type="checkbox")
+          input.Code.filterOption(val="has_code", id=hash, type="checkbox")
           | With code
       li.filterEntry
         - var hash = md5('code' + 'is_cif');
         label.dynatree-title(for=hash)
-          input.filterOption(val="is_cif", id=hash, type="checkbox")
+          input.Code.filterOption(val="is_cif", id=hash, type="checkbox")
           | Code in Flight

--- a/girder-tech-journal-gui/src/pages/home/journal_main_license_filter.pug
+++ b/girder-tech-journal-gui/src/pages/home/journal_main_license_filter.pug
@@ -8,5 +8,5 @@
         li.filterEntry
           - var hash = md5('license' + license);
           label.dynatree-title(for=hash)
-            input.filterOption(val=license, id=hash, type="checkbox")
+            input.License.filterOption(val=license, id=hash, type="checkbox")
             | #{license}

--- a/girder-tech-journal-gui/src/pages/home/journal_main_review_filter.pug
+++ b/girder-tech-journal-gui/src/pages/home/journal_main_review_filter.pug
@@ -3,14 +3,14 @@
   .categoryTree
     ul.dynatree-container
       li.filterEntry
-        input.filterOption(val="1", type="checkbox")
+        input.Certified.filterOption(val="1", type="checkbox")
         a.dynatree-title(href="#") Level 1
       li.filterEntry
-        input.filterOption(val="2", type="checkbox")
+        input.Certified.filterOption(val="2", type="checkbox")
         a.dynatree-title(href="#") Level 2
       li.filterEntry
-        input.filterOption(val="3", type="checkbox")
+        input.Certified.filterOption(val="3", type="checkbox")
         a.dynatree-title(href="#") Level 3
       li.filterEntry
-        input.filterOption(val="4", type="checkbox")
+        input.Certified.filterOption(val="4", type="checkbox")
         a.dynatree-title(href="#") Level 4

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -139,7 +139,7 @@ class TechJournal(Resource):
                         searchObj = "source-license"
                     elif category == "Certified":
                         searchObj = "certification_level"
-                    elif category == "OSEHRA VistA":
+                    elif category == "OSEHRA":
                         searchObj = "osehra_core"
                     if searchObj in revision["meta"].keys():
                         revisionMatch[0] = revisionMatch[0] or checkValue(
@@ -706,7 +706,7 @@ class TechJournal(Resource):
                             searchObj = "source-license"
                         elif category == "Certified":
                             searchObj = "certification_level"
-                        elif category == "OSEHRA VistA":
+                        elif category == "OSEHRA":
                             searchObj = "osehra_core"
                         foundMatch = self.checkSubmission(filterParams,
                                                           submission,


### PR DESCRIPTION
Use an global variable in the "window" object to pass the last
search query between views.  This should be used to ensure the same search
parameters are used when a user returns to the main page after selecting a submission.

This value shouldn't survive a hard refresh or clicking the "Clear" button