### PR TITLE
Fix title checking

### DIFF
--- a/girder-tech-journal-gui/src/pages/submit/journal_select_issue.pug
+++ b/girder-tech-journal-gui/src/pages/submit/journal_select_issue.pug
@@ -4,11 +4,11 @@ mixin issueEntry(info)
     td
       | #{info.parentName}
     td
-      a.issueGen(target=info._id) #{info.name}
+      a.issueGen(target=info._id, journal=info.parentId) #{info.name}
     td
       | #{info.daysLeft}
     td.actions
-      a.issueGen(target=info._id) Select Issue
+      a.issueGen(target=info._id, journal=info.parentId) Select Issue
       a#showDetails(target=info._id) Show details
 
 #pageContent

--- a/girder-tech-journal-gui/src/pages/submit/submit.js
+++ b/girder-tech-journal-gui/src/pages/submit/submit.js
@@ -24,7 +24,8 @@ var SubmitView = View.extend({
             }
         },
         'click .issueGen': function (event) {
-            this.parentID = event.currentTarget.target;
+            this.parentID = event.currentTarget.attributes['target'].value;
+            this.journalID = event.currentTarget.attributes['journal'].value;
             this.render(event.currentTarget.target, 2);
         },
         'submit #submitForm': function (event) {
@@ -120,6 +121,7 @@ var SubmitView = View.extend({
                         jrnResp.forEach(function (issue) {
                             // Append parent name to issue
                             issue['parentName'] = journalEntry['name'];
+                            issue['parentId'] = journalEntry['_id'];
                         });
                         // Keep track of all open issues
                         openIssues = openIssues.concat(jrnResp);


### PR DESCRIPTION
Fix the check for duplication that occurs when the new submission "Title"
object loses focus.  The submission shouldn't be allowed to move to the next
step if a duplicate title exists within the target issue.