### PR TITLE
Fix editing of Category lists

### DIFF
--- a/girder-tech-journal-gui/src/pages/adminCategories/adminCategories.js
+++ b/girder-tech-journal-gui/src/pages/adminCategories/adminCategories.js
@@ -17,40 +17,35 @@ const adminCategoriesPage = View.extend({
             });
         },
         'click .AddRootLink': function (event) {
-            $('.AddRootCategory').show();
+            this.$(event.currentTarget.parentNode).find('.AddRootCategory').show();
         },
-        'click .categoryObj': function (event) {
+        /* 'click .categoryObj': function (event) {
             this.categoryObj = event.currentTarget;
             $('.AddCategory').show();
-        },
+        }, */
         'submit #addTree': function (event) {
             event.preventDefault();
             var newCatName = this.$('#newTreeName').val();
             //  Call out to category API to save initial object
             restRequest({
                 method: 'POST',
-                url: `journal/category?text=${newCatName}&tag=disclaimer`
+                url: `journal/category?text=${newCatName}&tag=categories`
             }).done((resp) => {
                 this.$('#treeWrapper').html(this.$('#treeWrapper').html() + adminCategoriesEntryTemplate({'name': newCatName, 'values': []}));
             });
         },
         'submit #addRootCategoryForm': function (event) {
             event.preventDefault();
-            var parent = $(event.currentTarget).parent();
-            parent.siblings('.categoryTree').find('.categoryList').append('<li class="categoryObj">' + $(event.currentTarget).children().first().val() + '</li>');
-            var catName = parent.siblings('h4').text();
-            var valueData = {'key': catName, 'value': []};
-            parent.siblings('.categoryTree').find('.categoryList').find('li').each(function (index, val) {
-                valueData['value'].push($(val).text());
-            });
-
-            restRequest({
-                method: 'PUT',
-                url: 'journal/category?tag=categories',
-                data: {
-                    list: JSON.stringify([valueData])
-                }
-            });
+            var parent = $(event.currentTarget).closest('.TreeEntry');
+            parent.find('.categoryTree').find('.categoryList').append('<div class="categoryEntry"><li class="categoryObj">' +
+                                                                          $(event.currentTarget).children().first().val() +
+                                                                          '</li>&nbsp<a class="removeCategory">Remove</a></div>');
+            this.updateCategory(parent);
+        },
+        'click .removeCategory': function (event) {
+            var parent = $(event.currentTarget).closest('.TreeEntry');
+            $(event.currentTarget).closest('.categoryEntry').remove();
+            this.updateCategory(parent);
         },
         'submit #addNewChildCategory': function (event) {
             event.preventDefault();
@@ -76,6 +71,20 @@ const adminCategoriesPage = View.extend({
             parentView: this
         });
         return this;
+    },
+    updateCategory: function (treeEntry) {
+        var catName = treeEntry.find('h4').text();
+        var valueData = {'key': catName, 'value': []};
+        treeEntry.find('.categoryTree').find('.categoryList').find('li').each(function (index, val) {
+            valueData['value'].push($(val).text());
+        });
+        restRequest({
+            method: 'PUT',
+            url: 'journal/category?tag=categories',
+            data: {
+                list: JSON.stringify([valueData])
+            }
+        });
     }
 });
 

--- a/girder-tech-journal-gui/src/pages/adminCategories/adminCategories_entry.pug
+++ b/girder-tech-journal-gui/src/pages/adminCategories/adminCategories_entry.pug
@@ -1,6 +1,8 @@
 mixin addVal(entryName)
-  li.categoryObj
-    |#{entryName}
+  .categoryEntry
+    li.categoryObj
+      |#{entryName}&nbsp
+    a.removeCategory Remove
 .TreeEntry
   h4 #{name}
   a.AddRootLink (Add root Category)


### PR DESCRIPTION
Ensure new categories are saved as categories
Only show "new object" form for the category that is being manipulated
Remove "subcategory" event, as the pages is not ready for that
Consolidate the updating of the categories in the database.

Fixes #184 