### PR TITLE
Fix style and order of Revision table

### DIFF
--- a/girder-tech-journal-gui/src/stylesheets/view.index.styl
+++ b/girder-tech-journal-gui/src/stylesheets/view.index.styl
@@ -205,19 +205,15 @@ table
     th
       &:nth-of-type(even)
         background darken($primaryColor, 6%)
-    td
-      &:nth-of-type(even)
-        background darken(white, 3%)
 
 th, td
   padding 10px
-
+  border 1px #DDD solid
 th
   background $primaryColor
   color white
 
 td
-  border none
   &.actions
     a
       background $primaryColor
@@ -235,7 +231,8 @@ tr.clickable-row
   cursor pointer
 
 tr.selected
-  font-weight bold
+  background-color #56758B!important
+  color #fff!important
   td:first-of-type
     div
       position relative

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -374,6 +374,7 @@ class TechJournal(Resource):
                                          force=True)
         revisions = list(self.model('folder').childFolders(info, 'folder'))
         revisions.sort(key=sortByDate)
+        revisions.reverse()
         for rev in revisions:
             rev['submitter'] = self.model('user').load(
                 rev['creatorId'],


### PR DESCRIPTION
Fix the style to use the current format of highlighting the current
revision with a darker background color.  Reverse the list of objects
coming from the API value to show the most recent submission first.

Fixes #174 and #175