### PR TITLE
Cancel all rest requests before searching

### DIFF
--- a/girder-tech-journal-gui/src/pages/home/home.js
+++ b/girder-tech-journal-gui/src/pages/home/home.js
@@ -1,7 +1,7 @@
 import View from '@girder/core/views/View';
 import router from '@girder/core/router';
 import Accordion from 'accordion';
-import { restRequest, apiRoot } from '@girder/core/rest';
+import { cancelRestRequests, restRequest, apiRoot } from '@girder/core/rest';
 
 import MenuBarView from '../../views/menuBar.js';
 import HomeTemplate from './home.pug';
@@ -187,6 +187,7 @@ const HomePage = View.extend({
     },
     querySubmissions: function (collection, queryString, startIndex) {
         window.query = queryString;
+        cancelRestRequests();
         restRequest({
             method: 'GET',
             url: `journal/${collection}/search?query={` + encodeURIComponent(queryString) + '}'


### PR DESCRIPTION
This will prevent a race condition where an earlier search will
overwrite the content on the screen if it takes a longer time to find
than the later search.

For #173 