### PR TITLE
Add download links to upload pages

### DIFF
--- a/girder-tech-journal-gui/src/pages/upload/journal_upload_entry.pug
+++ b/girder-tech-journal-gui/src/pages/upload/journal_upload_entry.pug
@@ -1,5 +1,11 @@
 tr(key=info._id)
-  td #{info.name}
+  td
+    unless root
+      |  #{info.name}
+    if root
+      - filepath = root+ "/item/"+ info._id+ "/download"
+      a(href=filepath) #{info.name}
+
   td #{info.meta.type}
   td
     a.deleteLink Delete

--- a/girder-tech-journal-gui/src/pages/upload/upload.js
+++ b/girder-tech-journal-gui/src/pages/upload/upload.js
@@ -5,7 +5,7 @@ import FolderModel from '@girder/core/models/FolderModel';
 import UploadWidget from '@girder/core/views/widgets/UploadWidget';
 import { getCurrentUser } from '@girder/core/auth';
 import { handleClose } from '@girder/core/dialog';
-import { restRequest } from '@girder/core/rest';
+import { restRequest, apiRoot } from '@girder/core/rest';
 
 import MenuBarView from '../../views/menuBar.js';
 import UploadViewTemplate from './journal_upload.pug';
@@ -132,7 +132,7 @@ var uploadView = View.extend({
                 url: `item?folderId=${this.parentId}`
             }).done((itemResp) => {
                 for (var index in itemResp) {
-                    this.$('#uploadTable').append(UploadEntryTemplate({info: itemResp[index]}));
+                    this.$('#uploadTable').append(UploadEntryTemplate({info: itemResp[index], 'root': apiRoot}));
                     this.$('#uploadQuestions').show();
                     this.$('#acceptRights').prop('checked', 'checked');
                     this.$('#acceptLicense').prop('checked', 'checked');
@@ -200,7 +200,7 @@ var uploadView = View.extend({
                     data: JSON.stringify(subData),
                     error: null
                 }).done((respMD) => {
-                    this.$('#uploadTable').append(UploadEntryTemplate({info: respMD}));
+                    this.$('#uploadTable').append(UploadEntryTemplate({info: respMD, 'root': apiRoot}));
                     this.$('#uploadQuestions').show();
                     this.submitCheck();
                 });

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -974,7 +974,7 @@ class TechJournal(Resource):
                                                         creator=self.getCurrentUser(),
                                                         folder=folder,
                                                         description=metadata['github'])
-                self.model("item").setMetadata(newItem, {'type': 6})
+                self.model("item").setMetadata(newItem, {'type': "GITHUB"})
                 processGithub.delay(metadata['github'],
                                     girder_result_hooks=[GirderUploadToItem(str(newItem['_id'])), ])
             else:


### PR DESCRIPTION
As new files are uploaded, change the name string into a link
which can download the file.  This will be especially helpful for admins
who are approving the submissions.

Git repository links should not exist right away.  Once girder worker has
captured the zip file, the link should appear and be valid.

Fixes #183 