### PR TITLE
Ensure that the permissions values are set on Revisions

### DIFF
--- a/girder-tech-journal-gui/src/pages/submit/editSubmission.js
+++ b/girder-tech-journal-gui/src/pages/submit/editSubmission.js
@@ -172,6 +172,8 @@ var editView = View.extend({
             'type': this.$('#typeEntry').val().trim(),
             'copyright': this.$('#copyrightEntry').val().trim(),
             'grant': this.$('#grantEntry').val().trim(),
+            'permission': this.$('.subPermission:checked').val(),
+            'CorpCLA': this.$('.CLAPermission:checked').val(),
             'authors': authors,
             'tags': tags,
             'categories': categories,


### PR DESCRIPTION
To ensure that the values of Corporate CLA and "Permission to Submit"
are filled in when new revisions are created, set the etadata values for each
on each revision instead of just the first one.

Fixes #186 