### PR TITLE
Statistics page updates

### DIFF
--- a/girder-tech-journal-gui/src/pages/StatisticsPage.vue
+++ b/girder-tech-journal-gui/src/pages/StatisticsPage.vue
@@ -8,6 +8,7 @@ div
           a(@click="targetYear-=1") Previous Year
           |,
           a(@click="targetYear+=1") Next Year
+          img#loadingWheel(src='@/assets/loading-small.gif')
           h4 Overall Statistics
           table
             thead
@@ -89,7 +90,7 @@ div
                   a(:href="getHref(item.meta.submissionNumber)") {{item.name}}
                 td {{item.license}}
                 td {{item.meta.attributionPolicy}}
-                td {{item.created}}
+                td {{item.updated}}
                 td {{item.views}}
                 td {{item.downloads}}
 
@@ -123,19 +124,26 @@ export default {
         ]),
       },
     });
-    this.targetYear = new Date().getFullYear();
+    $('#loadingWheel').hide(); // eslint-disable-line no-undef
+    if (this.$options.propsData.year) {
+      this.targetYear = this.$options.propsData.year;
+    } else {
+      this.targetYear = new Date().getFullYear();
+    }
   },
   methods: {
     getHref(number) {
       return `#view/${number}`;
     },
     async findSubmissions(id) {
+      $('#loadingWheel').show(); // eslint-disable-line no-undef
       this.statisticsData = await restRequest({
         method: 'GET',
         url: `journal/${id}/statistics?year=${this.targetYear}`,
       });
       this.submissions = this.statisticsData.total;
       this.monthly = this.statisticsData.monthly;
+      $('#loadingWheel').hide(); // eslint-disable-line no-undef
     },
   },
 };

--- a/girder-tech-journal-gui/src/routes.js
+++ b/girder-tech-journal-gui/src/routes.js
@@ -77,8 +77,21 @@ router.route('journals', 'JournalListPage', function () {
 
 // Listing page of Journal
 import StatisticsPage from '@/pages/StatisticsPage.vue';
-router.route('statistics', 'JournalListPage', function () {
-    testUserAccess(vueComponentView, {component: StatisticsPage}, false, false);
+router.route('statistics/:id', 'JournalListPage', function (id) {
+    testUserAccess(vueComponentView, {
+        component: StatisticsPage,
+        props: {
+            'year': id
+        }
+    }, false, false);
+});
+router.route('statistics', 'JournalListPage', function (id) {
+    testUserAccess(vueComponentView, {
+        component: StatisticsPage,
+        props: {
+            'year': ''
+        }
+    }, false, false);
 });
 
 import uploadView from './pages/upload/upload';


### PR DESCRIPTION
Ensure that the submissions found during the statistics gathering are
only from the default collection given.

Add a loading wheel to hightlight that the page is doing something and not
frozen.

Change how submissions are collected to ensure that duplicates are not found

Ensure that a year could be appended to the URL to jump directly to the
targeted year.