### PR TITLE
Add note for MySQL version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,17 @@ documentation to enable the Node.js APT repository, use:
 
 ``curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -``
 
+**Note:** The Technical Journal plugin requires that MongoDB is at least 3.4+. When following the
+documentation to install MongoDB, replace '3.2' with '3.4'
+
+``echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.4 main" \
+    | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list``
+
+or
+
+``echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" \
+    | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list``
+
 
 Set up Technical Journal plugin
 +++++++++++++++++++++++++++++++


### PR DESCRIPTION
Ensure that the TJ plugin documentation has a note about the statistics
page introducing a dependency on MongoDB 3.4+ due to the use of
"buckets" in the aggregation pipeline