### PR TITLE
Reload Disclaimer page on save

### DIFF
--- a/girder-tech-journal-gui/src/pages/admin/manageDisclaimers.js
+++ b/girder-tech-journal-gui/src/pages/admin/manageDisclaimers.js
@@ -65,6 +65,7 @@ var ManageDisclaimerView = View.extend({
             },
             error: null
         }).done((resp) => {
+            window.location.reload();
             events.trigger('g:alert', {
                 icon: 'ok',
                 text: 'Disclaimer saved.',


### PR DESCRIPTION
Reload the Disclaimer administration page after saving the current disclaimer.
This will place new disclaimers in to the pull down to be selected again.