### PR TITLE
Ensure revisions are sorted by created date too

### DIFF
--- a/girder_tech_journal/api/tech_journal.py
+++ b/girder_tech_journal/api/tech_journal.py
@@ -98,6 +98,7 @@ class TechJournal(Resource):
                                           user=self.getCurrentUser()))
         # If not found in the top level data, search through each revision
         if not keyMatch[0]:
+            revisionInfo = sorted(revisionInfo, key=lambda revision: revision['updated'])
             for revision in revisionInfo:
                 revisionMatch = [False, -1]
                 for key in filterParams[category]:


### PR DESCRIPTION
Ensure that when filtering over revisions, that they are sorted by
updated datetime as well.  This will let the "latest" matching
revision be found correctly.