### PR TITLE
Fix VUE.js warning about multiple attributes

### DIFF
--- a/girder-tech-journal-gui/src/pages/StatisticsPage.vue
+++ b/girder-tech-journal-gui/src/pages/StatisticsPage.vue
@@ -8,7 +8,7 @@ div
           a(@click="targetYear-=1") Previous Year
           |,
           a(@click="targetYear+=1") Next Year
-          img(v-show="loading")#loadingWheel(src='@/assets/loading-small.gif')
+          img#loadingWheel(src='@/assets/loading-small.gif', v-show="loading")
           h4 Overall Statistics
           table
             thead


### PR DESCRIPTION
Fix the object in the StatisticsPage.vue code which attempts to add
multiple sets of attributes.  Change the attributes to be set in the
same set of "()"