### PR TITLE
Switch back to using Journal model for TJ settings

### DIFF
--- a/girder_tech_journal/api/tech_journal.py
+++ b/girder_tech_journal/api/tech_journal.py
@@ -15,7 +15,6 @@ from girder.models import getDbConnection
 from girder.models.collection import Collection
 from girder.models.folder import Folder
 from girder.models.item import Item
-from girder.models.setting import Setting
 from girder.models.upload import Upload
 from girder.models.user import User
 from girder.utility import mail_utils
@@ -412,7 +411,7 @@ class TechJournal(Resource):
         .errorResponse('Read access was denied on the issue.', 403)
     )
     def getNewSubmissionNumber(self, params):
-        s = Setting()
+        s = Journal()
 
         nextNum = s.get('technical_journal.submission')
         if nextNum is None:
@@ -431,7 +430,7 @@ class TechJournal(Resource):
         .errorResponse('Read access was denied on the issue.', 403)
     )
     def getNewRevisionNumber(self, submission, params):
-        s = Setting()
+        s = Journal()
 
         key = 'technical_journal.submission.%s' % (submission)
 

--- a/girder_tech_journal/models/journal.py
+++ b/girder_tech_journal/models/journal.py
@@ -1,6 +1,6 @@
 from girder.models.model_base import AccessControlledModel
 
-# from girder_tech_journal.constants import TechJournalSettingsDefault
+from girder_tech_journal.settings import TechJournalSettingsDefault
 
 
 class Journal(AccessControlledModel):

--- a/girder_tech_journal/settings.py
+++ b/girder_tech_journal/settings.py
@@ -1,49 +1,18 @@
-import six
-
-from girder.utility import setting_utilities
-from girder.exceptions import ValidationException
-
-
 class TechJournalSettings(object):
     ADMIN_EMAIL = 'tech_journal.admin_email'
     DEFAULT_JOURNAL = 'tech_journal.default_journal'
     DEFAULT_LAYOUT = 'tech_journal.default_layout'
     BASE_HANDLE = 'tech_journal.base_handle'
     OLD_URL = 'tech_journal.old_url'
+    SUBMISSION = 'tech_journal.submission'
 
 
-@setting_utilities.default(TechJournalSettings.ADMIN_EMAIL)
-def _defaultAdminEmail():
-    return ''
-
-
-@setting_utilities.default(TechJournalSettings.DEFAULT_JOURNAL)
-def _defaultDefaultJournal():
-    return ''
-
-
-@setting_utilities.default(TechJournalSettings.DEFAULT_LAYOUT)
-def _defaultDefaultLayout():
-    return ''
-
-
-@setting_utilities.default(TechJournalSettings.BASE_HANDLE)
-def _defaultBaseHandle():
-    return ''
-
-
-@setting_utilities.default(TechJournalSettings.OLD_URL)
-def _defaultOldUrl():
-    return ''
-
-
-@setting_utilities.validator(TechJournalSettings.ADMIN_EMAIL)
-def validateSettings(doc):
-    if doc['value']:
-        if not isinstance(doc['value'], six.string_types):
-            raise ValidationException(
-                'Tech Journal Resources must be a string.', 'value')
-        # accept comma or space separated lists
-        resources = doc['value'].replace(',', ' ').strip().split()
-        # reformat to a comma-separated list
-        doc['value'] = ','.join(resources)
+class TechJournalSettingsDefault(object):
+    defaults = {
+        TechJournalSettings.ADMIN_EMAIL: "",
+        TechJournalSettings.DEFAULT_JOURNAL: "",
+        TechJournalSettings.DEFAULT_LAYOUT: "",
+        TechJournalSettings.BASE_HANDLE: "",
+        TechJournalSettings.OLD_URL: "",
+        TechJournalSettings.SUBMISSION: 0
+    }


### PR DESCRIPTION
Switch the "settings" being set in the Tech Journal API to use
the Tech Journal model for storage instead of the Girder "settings"
model.