### PR TITLE
Switch CI docker to py3

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM girder/girder_test:latest-py2
+FROM girder/girder_test:latest-py3
 
 # Don't use "sudo"
 USER root


### PR DESCRIPTION
Switch the Docker container used for CI to use Python3 instead.