### PR TITLE
Remove blank href for admin menu option

### DIFF
--- a/girder-tech-journal-gui/src/templates/journal_menu_bar.pug
+++ b/girder-tech-journal-gui/src/templates/journal_menu_bar.pug
@@ -62,7 +62,7 @@
                 a.submm(href='#plugins/user/' + user.id + '/edit') Edit Profile
           if user.attributes.admin
             li#adminLink
-              a(href="") Admin
+              a(href='#plugins/journal/admin') Admin
               ul#adminOptionsList
                 li
                   a.submm(href='#plugins/journal/admin') Journals


### PR DESCRIPTION
Ensure that if the user clicks on the "Admin" link in the menu bar,
that it takes the user to the "Admin Journals" page instead of the main
page.